### PR TITLE
Hotfix: Icons Render Queue

### DIFF
--- a/src/robtop/iconkit/useGDIcon.ts
+++ b/src/robtop/iconkit/useGDIcon.ts
@@ -136,7 +136,7 @@ export const useGDIconRef = ({
       }
       setLoading(false)
     }
-    queueMicrotask(logic)
+    setTimeout(logic)
   }, [c1, c2, c3, glow, iconNumber, type, username])
 
   return { icon: finalImage, loading }
@@ -175,9 +175,10 @@ export const useGDIcon = ({
         hostURL,
         username
       })
+      console.log(img)
       if (img) setIcon(img)
     }
-    queueMicrotask(logic)
+    setTimeout(logic)
   }, [type, iconNumber, c1, c2, c3, glow, username])
 
   return { icon: iconSrc }


### PR DESCRIPTION
Observaciones:

Cada icono tarda en renderizarse alrededor de 50ms
Una carga completa de 50 iconos en algún ranking, tarda en el mejor de los casos 5 segundos.

Tareas
* [X] Microtasks se buguean en Android
* [ ] Agregar Web Worker
* [ ] Crear una cola de renderizado en el contexto global de ser necesario (utilizando un Web Worker)
* [ ] Solucionar conflictos